### PR TITLE
Implement using scale calibration data

### DIFF
--- a/+FV_Controller/Brillouin.m
+++ b/+FV_Controller/Brillouin.m
@@ -36,6 +36,7 @@ function loadRepetition(model, repetition)
             data = load(filepath, 'results');
             
             Brillouin.date = model.file.readPayloadData('Brillouin', Brillouin.repetition.name, 'date', 0);
+                
             
             if isfield(data.results.results, 'BrillouinShift_frequency_normalized')
                 Brillouin.shift = data.results.results.BrillouinShift_frequency_normalized;

--- a/+FV_Controller/Data.m
+++ b/+FV_Controller/Data.m
@@ -88,6 +88,7 @@ function openFile(model, filePath)
         
         model.controllers.Brillouin.loadRepetition();
         model.controllers.ODT.loadRepetition();
+        model.controllers.fluorescence.loadRepetition();
         loadAlignmentData(model);
     end
 end

--- a/+FV_Controller/Fluorescence.m
+++ b/+FV_Controller/Fluorescence.m
@@ -6,6 +6,7 @@ function callbacks = Fluorescence(model, view)
     set(view.Fluorescence.channels, 'ValueChangedFcn', {@selectChannel, model});
 
     callbacks = struct( ...
+        'loadRepetition', @()loadRepetition(model, model.Fluorescence.repetition, model.Fluorescence.channel) ...
     );
 end
 
@@ -14,11 +15,84 @@ function selectRepetition(src, ~, model)
     items = get(src, 'Items');
     repetition.index = find(strcmp(items, val));
     repetition.name = model.Fluorescence.repetitions{repetition.index};
-    model.Fluorescence.repetition = repetition;
+    loadRepetition(model, repetition, model.Fluorescence.channel);
 end
 
 function selectChannel(src, ~, model)
     val = get(src, 'Value');
     items = get(src, 'Items');
-    model.Fluorescence.channel = find(strcmp(items, val));
+    channel = find(strcmp(items, val));
+    loadRepetition(model, model.Fluorescence.repetition, channel);
+end
+
+function loadRepetition(model, repetition, channel)
+    Fluorescence = model.Fluorescence;
+    
+    Fluorescence.repetition = repetition;
+    Fluorescence.channel = channel;
+    
+    if ~isempty(Fluorescence.repetitions)
+        try
+
+            Fluorescence.channelNames = model.file.readPayloadData('Fluorescence', Fluorescence.repetition.name, 'memberNames');
+            if (Fluorescence.channel > length(Fluorescence.channelNames))
+                Fluorescence.channel = 1;
+            end
+
+            Fluorescence.channelName = Fluorescence.channelNames{Fluorescence.channel};
+
+            Fluorescence.type = model.file.readPayloadData('Fluorescence', Fluorescence.repetition.name, 'channel', Fluorescence.channelName);
+
+            data = model.file.readPayloadData('Fluorescence', Fluorescence.repetition.name, 'data', Fluorescence.channelName);
+            data = medfilt1(data, 3);
+            Fluorescence.date = model.file.readPayloadData('Fluorescence', Fluorescence.repetition.name, 'date', Fluorescence.channelName);
+
+            try
+                scaleCalibration = model.file.getScaleCalibration('Fluorescence', Fluorescence.repetition.name);
+            
+                Fluorescence.ROI = model.file.readPayloadData('Fluorescence', Fluorescence.repetition.name, 'ROI', Fluorescence.channelName);
+                
+                [pixX, pixY] = meshgrid( ...
+                    (0:(Fluorescence.ROI.width_physical - 1)) + Fluorescence.ROI.left, ...
+                    (0:(Fluorescence.ROI.height_physical - 1)) + Fluorescence.ROI.bottom);
+                
+                pixX = pixX - scaleCalibration.origin(1);
+                pixY = pixY - scaleCalibration.origin(2);
+                
+                micrometerX = pixX .* scaleCalibration.pixToMicrometerX(1) + pixY .* scaleCalibration.pixToMicrometerY(1) + ...
+                    scaleCalibration.positionStage(1);
+                micrometerY = pixX .* scaleCalibration.pixToMicrometerX(2) + pixY .* scaleCalibration.pixToMicrometerY(2) + ...
+                    scaleCalibration.positionStage(2);
+                
+                %% Interpolate data for imagesc
+                % See FV_View\Fluorescence.m#L91 for why the hell this is
+                % necessary.
+                x = linspace(min(micrometerX, [], 'all'), max(micrometerX, [], 'all'), round(size(micrometerX, 2)/2));
+                y = linspace(min(micrometerY, [], 'all'), max(micrometerY, [], 'all'), round(size(micrometerY, 1)/2));
+                
+                [Xq, Yq] = meshgrid(x, y);
+                
+                data = griddata(micrometerX, micrometerY, data, Xq, Yq);
+            catch
+                x = 4.8*(1:size(data, 1))/57;
+                x = x - nanmean(x(:));
+                y = 4.8*(1:size(data, 2))/57;
+                y = y - nanmean(y(:));
+            end
+            Fluorescence.data = data;
+
+            Fluorescence.positions.x = x;
+            Fluorescence.positions.y = y;
+        catch
+            Fluorescence.data = NaN;
+            Fluorescence.date = '';
+            Fluorescence.positions = struct( ...
+                'x', [], ...
+                'y', [], ...
+                'z', [] ...
+            );
+        end
+    end
+    
+    model.Fluorescence = Fluorescence;
 end

--- a/+FV_Controller/ODT.m
+++ b/+FV_Controller/ODT.m
@@ -39,14 +39,20 @@ function loadRepetition(model, view, repetition)
 
             ODT.date = model.file.readPayloadData('ODT', ODT.repetition.name, 'date', 0);
             
-            ZP4 = round(size(ODT.data.Reconimg,1));
-            x = ((1:ZP4)-ZP4/2)*ODT.data.res3;
-            y = x;
+            try
+                scaleCalibration = model.file.getScaleCalibration('ODT', ODT.repetition.name);
             
-            ZP5 = round(size(ODT.data.Reconimg,3));
-            z = fliplr(((1:ZP5)-ZP5/2)*ODT.data.res4);
-            
-            [X, Y, Z] = meshgrid(x, y, z);
+                ODT.ROI = model.file.readPayloadData('ODT', Fluorescence.repetition.name, 'ROI', 0);
+            catch
+                ZP4 = round(size(ODT.data.Reconimg,1));
+                x = ((1:ZP4)-ZP4/2)*ODT.data.res3;
+                y = x;
+
+                ZP5 = round(size(ODT.data.Reconimg,3));
+                z = fliplr(((1:ZP5)-ZP5/2)*ODT.data.res4);
+
+                [X, Y, Z] = meshgrid(x, y, z);
+            end
             
             ODT.positions.x = X;
             ODT.positions.y = Y;


### PR DESCRIPTION
Uses the scale calibration data to properly overlay Fluorescence, ODT and Brillouin microscopy data.

Requires https://github.com/BrillouinMicroscopy/BrillouinAcquisition/pull/193.

Closes #9.